### PR TITLE
Fix missing execution block for apt > 2.4.0, where it was changed to...

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,7 +7,7 @@ apt_repository "brightbox-ruby-ng-#{node['lsb']['codename']}" do
   keyserver    "keyserver.ubuntu.com"
   key          "C3173AA6"
   action       :add
-  notifies     :run, "execute[apt-get update]", :immediately
+  notifies     :run, "execute[apt-get-update]", :immediately
 end
 
 # install Ruby


### PR DESCRIPTION
apt-get-update.
